### PR TITLE
Fix CI: Only push NuGet packages from master branch

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,6 +29,8 @@ jobs:
     - name: NuGet (pack)
       run: dotnet pack --configuration Release
     - name: NuGet (push, 1)
-      run: dotnet nuget push src/EvolutionaryAlgorithm/bin/Release/*.nupkg -k ${{ secrets.GITHUB_TOKEN }} -s https://nuget.pkg.github.com/simontjell/index.json
+      if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      run: dotnet nuget push src/EvolutionaryAlgorithm/bin/Release/*.nupkg -k ${{ secrets.GITHUB_TOKEN }} -s https://nuget.pkg.github.com/simontjell/index.json --skip-duplicate
     - name: NuGet (push, 2)
-      run: dotnet nuget push src/DifferentialEvolution/bin/Release/*.nupkg -k ${{ secrets.GITHUB_TOKEN }} -s https://nuget.pkg.github.com/simontjell/index.json
+      if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      run: dotnet nuget push src/DifferentialEvolution/bin/Release/*.nupkg -k ${{ secrets.GITHUB_TOKEN }} -s https://nuget.pkg.github.com/simontjell/index.json --skip-duplicate

--- a/src/DifferentialEvolution/DifferentialEvolution.csproj
+++ b/src/DifferentialEvolution/DifferentialEvolution.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <Version>0.0.4</Version>
+    <Version>0.0.5</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EvolutionaryAlgorithm\EvolutionaryAlgorithm.csproj">

--- a/src/EvolutionaryAlgorithm/EvolutionaryAlgorithm.csproj
+++ b/src/EvolutionaryAlgorithm/EvolutionaryAlgorithm.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <Version>0.0.4</Version>
+    <Version>0.0.5</Version>
   </PropertyGroup>
   <ItemGroup>
   </ItemGroup>


### PR DESCRIPTION
## Summary  
- Fix CI failures on master caused by duplicate version conflicts
- Configure workflow to only push NuGet packages from master branch (not PRs)
- Bump version to 0.0.5 to resolve current conflict

## Problem
The current workflow pushes NuGet packages from both PR branches and master, causing version conflicts when PRs are merged. Version 0.0.4 was already pushed from the PR branch, so master fails when trying to push the same version.

## Solution
1. **Conditional NuGet Push**: Only push packages when `github.ref == 'refs/heads/master' && github.event_name == 'push'`
2. **Skip Duplicates**: Add `--skip-duplicate` flag as additional safety measure
3. **Version Bump**: Increase to 0.0.5 to resolve current conflict

## Changes
- `.github/workflows/dotnet.yml`: Add conditions to NuGet push steps
- `src/*/**.csproj`: Bump version from 0.0.4 to 0.0.5

This ensures only releases from master are published to avoid conflicts.

🤖 Generated with [Claude Code](https://claude.ai/code)